### PR TITLE
Use syn, proc_macro2 and quote stable versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "0.4.30"
-syn = "0.15.39"
-quote = "0.6.12"
+proc-macro2 = "1"
+syn = "1"
+quote = "1"


### PR DESCRIPTION
This avoids haiving to compile this packages twice when using derive_destructure in combination with other crates that use the stable versions of proc_macro2, syn and quote which helps reducing compile times greatly in those cases